### PR TITLE
Fix build-pricing caching

### DIFF
--- a/.github/workflows/build-pricing.yml
+++ b/.github/workflows/build-pricing.yml
@@ -28,9 +28,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'gcosts/go.mod'
-          cache-dependency-path: |
-            'build/go.sum'
-            'gcosts/go.sum'
+          cache-dependency-path: '**/go.sum'
 
       # Compile build/skus CLI
       - name: 🍳 Build build/skus

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'gcosts/go.mod'
-          cache-dependency-path: |
-            'build/go.sum'
-            'gcosts/go.sum'
+          cache-dependency-path: '**/go.sum'
 
       # https://github.com/marketplace/actions/run-golangci-lint
       - name: 🌡️ Lint build


### PR DESCRIPTION
First off, thanks for taking the time to contribute!

## Please Complete the Following

- [x] I read `CONTRIBUTING.md`
- [x] I used tabs to indent
- [x] I have tested my change

## Notes

By some reason (probably, a bug in setup-go GitHub Action), Go caching
didn't work:
```
Warning: Restore cache failed: Some specified paths were not resolved, unable to cache dependencies.
```

Using glob for `cache-dependency-path` helps.

See:
https://github.com/Cyclenerd/google-cloud-pricing-cost-calculator/actions/runs/7824640796/job/21347515946#step:4:19
https://github.com/rominf/google-cloud-pricing-cost-calculator/actions/runs/7841511119/job/21397985015#step:4:22
