### PR TITLE
Add Local SSD capacities for C3/C3D; fix c4d-highmem-8/16-lssd typos

### DIFF
--- a/build/gcp.yml
+++ b/build/gcp.yml
@@ -901,36 +901,42 @@ compute:
     c3-standard-4-lssd:
       cpu: 4
       ram: 16
+      local-ssd: 375
     c3-standard-8:
       cpu: 8
       ram: 32
     c3-standard-8-lssd:
       cpu: 8
       ram: 32
+      local-ssd: 750
     c3-standard-22:
       cpu: 22
       ram: 88
     c3-standard-22-lssd:
       cpu: 22
       ram: 88
+      local-ssd: 1500
     c3-standard-44:
       cpu: 44
       ram: 176
     c3-standard-44-lssd:
       cpu: 44
       ram: 176
+      local-ssd: 3000
     c3-standard-88:
       cpu: 88
       ram: 352
     c3-standard-88-lssd:
       cpu: 88
       ram: 352
+      local-ssd: 6000
     c3-standard-176:
       cpu: 176
       ram: 704
     c3-standard-176-lssd:
       cpu: 176
       ram: 704
+      local-ssd: 12000
     c3-standard-192-metal:
       cpu: 192
       ram: 768
@@ -981,24 +987,28 @@ compute:
     c3d-standard-16-lssd:
       cpu: 16
       ram: 64
+      local-ssd: 375
     c3d-standard-16:
       cpu: 16
       ram: 64
     c3d-standard-180-lssd:
       cpu: 180
       ram: 720
+      local-ssd: 6000
     c3d-standard-180:
       cpu: 180
       ram: 720
     c3d-standard-30-lssd:
       cpu: 30
       ram: 120
+      local-ssd: 750
     c3d-standard-30:
       cpu: 30
       ram: 120
     c3d-standard-360-lssd:
       cpu: 360
       ram: 1440
+      local-ssd: 12000
     c3d-standard-360:
       cpu: 360
       ram: 1440
@@ -1008,18 +1018,21 @@ compute:
     c3d-standard-60-lssd:
       cpu: 60
       ram: 240
+      local-ssd: 1500
     c3d-standard-60:
       cpu: 60
       ram: 240
     c3d-standard-8-lssd:
       cpu: 8
       ram: 32
+      local-ssd: 375
     c3d-standard-8:
       cpu: 8
       ram: 32
     c3d-standard-90-lssd:
       cpu: 90
       ram: 360
+      local-ssd: 3000
     c3d-standard-90:
       cpu: 90
       ram: 360
@@ -1053,24 +1066,28 @@ compute:
     c3d-highmem-16-lssd:
       cpu: 16
       ram: 128
+      local-ssd: 375
     c3d-highmem-180:
       cpu: 180
       ram: 1440
     c3d-highmem-180-lssd:
       cpu: 180
       ram: 1440
+      local-ssd: 6000
     c3d-highmem-30:
       cpu: 30
       ram: 240
     c3d-highmem-30-lssd:
       cpu: 30
       ram: 240
+      local-ssd: 750
     c3d-highmem-360:
       cpu: 360
       ram: 2880
     c3d-highmem-360-lssd:
       cpu: 360
       ram: 2880
+      local-ssd: 12000
     c3d-highmem-4:
       cpu: 4
       ram: 32
@@ -1080,18 +1097,21 @@ compute:
     c3d-highmem-60-lssd:
       cpu: 60
       ram: 480
+      local-ssd: 1500
     c3d-highmem-8:
       cpu: 8
       ram: 64
     c3d-highmem-8-lssd:
       cpu: 8
       ram: 64
+      local-ssd: 375
     c3d-highmem-90:
       cpu: 90
       ram: 720
     c3d-highmem-90-lssd:
       cpu: 90
       ram: 720
+      local-ssd: 3000
 
     # C4:
     c4-highcpu-144:
@@ -1564,7 +1584,7 @@ compute:
     c4d-highmem-16-lssd:
       cpu: 16
       ram: 126
-      local-ssd: 3000
+      local-ssd: 375
     c4d-highmem-192-lssd:
       cpu: 192
       ram: 1512
@@ -1588,7 +1608,7 @@ compute:
     c4d-highmem-8-lssd:
       cpu: 8
       ram: 63
-      local-ssd: 2250
+      local-ssd: 375
     c4d-highmem-96-lssd:
       cpu: 96
       ram: 756

--- a/t/test_lssd_instances.pl
+++ b/t/test_lssd_instances.pl
@@ -37,22 +37,12 @@ my @lssd_instances;
 my $instances = $data->{compute}{instance};
 
 for my $instance_name (keys %{$instances}) {
-	# C3D
-	# https://docs.cloud.google.com/compute/docs/general-purpose-machines#c3d_disks
-	# To use Local SSD with C3D, create your VM using the -lssd variant of the C3D machine types.
-	# Selecting this machine type creates a VM of the specified size with Local SSD partitions attached.
-	# You must use a machine type that ends in -lssd to use Local SSD with your C3D VM;
-	# you can't attach Local SSD volumes separately.
-
-	# C3
-	# https://docs.cloud.google.com/compute/docs/general-purpose-machines#c3_disks
-	# A set amount of Local SSD disks are added to the C3 VM when you use the -lssd machine type.
-	# This is the only way to include Local SSD storage with a C3 VM.
-	if (
-		$instance_name =~ /-lssd/ &&
-		$instance_name !~ /c3d-/ &&
-		$instance_name !~ /c3-/
-	) {
+	# All machine types that end in -lssd bundle Local SSD partitions (375 GiB each).
+	# - C3:  https://docs.cloud.google.com/compute/docs/general-purpose-machines#c3_disks
+	# - C3D: https://docs.cloud.google.com/compute/docs/general-purpose-machines#c3d_disks
+	# - C4 / C4A / C4D: same page, #c4_disks / #c4a_disks / #c4d_disks
+	# - Z3:  https://docs.cloud.google.com/compute/docs/storage-optimized-machines
+	if ($instance_name =~ /-lssd/) {
 		push @lssd_instances, {
 		name => $instance_name,
 		data => $instances->{$instance_name}


### PR DESCRIPTION
## Summary

`build/gcp.yml` is missing `local-ssd:` for every C3 and C3D `-lssd` machine type (20 SKUs total). As a result, `build/pricing.pl` computes their bundled Local SSD cost as `0`, so the C3/C3D LSSD shapes are quoted at the same price as their non-LSSD siblings.

Concretely, `gcosts compute instance --type c3d-highmem-8-lssd` currently returns the price of `c3d-highmem-8` (no Local SSD), which is well below the actual rate. This appears to be a long-standing data gap — `t/test_lssd_instances.pl` already special-cased C3/C3D out of the invariant.

While auditing the C4D family I also noticed two entries with the wrong capacity (the values look like they were row-shifted from larger SKUs during data entry):

| SKU | Was | Should be |
|---|---|---|
| `c4d-highmem-8-lssd`  | `2250` | `375` (1 × 375 GiB) |
| `c4d-highmem-16-lssd` | `3000` | `375` (1 × 375 GiB) |

All capacities cross-checked against Google's [general-purpose machine family docs](https://docs.cloud.google.com/compute/docs/general-purpose-machines). Each Local SSD partition is 375 GiB.

## Changes

- **`build/gcp.yml`**: add 20 `local-ssd:` entries for every C3 and C3D `-lssd` shape; correct the two C4D values above.
- **`t/test_lssd_instances.pl`**: drop the `c3-`/`c3d-` exclusions so the LSSD-capacity invariant covers every `-lssd` machine type uniformly.

I'm deliberately **not** touching the top-level `pricing.yml` — the weekly `Build` workflow regenerates it from `build/gcp.yml` + live SKU prices.

## Test plan

- [x] `perl t/test_lssd_instances.pl` → 72/72 ok (up from 50/50, since C3+C3D are now in scope)
- [x] Manually verified the new capacities against the per-shape tables in https://docs.cloud.google.com/compute/docs/general-purpose-machines for both C3 (`#c3_disks`), C3D (`#c3d_disks`), and C4D (`#c4d_disks`)
- [ ] Maintainer to confirm next `Build` workflow regenerates `pricing.yml` cleanly (would need the GCP pricing API key, which I don't have)

## C3 capacities added

| SKU | Partitions | GiB |
|---|---:|---:|
| c3-standard-4-lssd     | 1  | 375    |
| c3-standard-8-lssd     | 2  | 750    |
| c3-standard-22-lssd    | 4  | 1,500  |
| c3-standard-44-lssd    | 8  | 3,000  |
| c3-standard-88-lssd    | 16 | 6,000  |
| c3-standard-176-lssd   | 32 | 12,000 |

## C3D capacities added

| SKU | Partitions | GiB |
|---|---:|---:|
| c3d-standard-8-lssd / c3d-highmem-8-lssd     | 1  | 375    |
| c3d-standard-16-lssd / c3d-highmem-16-lssd   | 1  | 375    |
| c3d-standard-30-lssd / c3d-highmem-30-lssd   | 2  | 750    |
| c3d-standard-60-lssd / c3d-highmem-60-lssd   | 4  | 1,500  |
| c3d-standard-90-lssd / c3d-highmem-90-lssd   | 8  | 3,000  |
| c3d-standard-180-lssd / c3d-highmem-180-lssd | 16 | 6,000  |
| c3d-standard-360-lssd / c3d-highmem-360-lssd | 32 | 12,000 |